### PR TITLE
fix: Adapt to changes in PDL to avoid exception computing date time scales

### DIFF
--- a/lib/Chart/GGPlot/Util/Scales.pm
+++ b/lib/Chart/GGPlot/Util/Scales.pm
@@ -754,7 +754,7 @@ fun pretty_dt($x, :$n = 5, :$min_n = $n % 2, %rest) {
             unless ( $nat->where( $nat > $at->at(-1) )->length == $nat->length ) {    # failed
                 $r2 = $at->length - 1;
             }
-            $at = $at->glue( 0, $nat );
+            $at = PDL::DateTime->new( $at->glue( 0, $nat ) );
         }
         return $at->slice( pdl( [ $r1 .. $r2 ] ) );
     };


### PR DESCRIPTION
Date time scales in some cases were failing with recent version of PDL (at least with version 2.080).
Some tests were also failing:

```
# Failed test 'pretty_breaks'
# at t/06-util_scales.t line 317.
# Caught exception in subtest: Can't locate object method "dt_unpdl" via package "PDL__WITH__PDL::Role::HasNames" at /home/liveapp/.cpanm/work/1659685258.2174913/Chart-GGPlot-0.002000/blib/lib/Chart/GGPlot/Util/Scales.pm line 604.
```
(fail extracted from [cpantesters](http://www.cpantesters.org/cpan/report/17a69422-1492-11ed-9439-0d661af29030))

I've tracked the problem to the method `PDL::glue` not preserving the type anymore.